### PR TITLE
Set composeApp as the name for expected local umbrella KMP framework to be pro…

### DIFF
--- a/FirebaseAuthKmp/Sources/FirebaseAuthKmpWrapperImpl.swift
+++ b/FirebaseAuthKmp/Sources/FirebaseAuthKmpWrapperImpl.swift
@@ -1,4 +1,4 @@
-import shared
+import composeApp
 import FirebaseAuth
 
 public class FirebaseAuthKmpWrapperImpl : MacaoFirebaseAuthKmpWrapper {


### PR DESCRIPTION
Set **composeApp** as the name for expected local umbrella KMP framework to be provided when building the topmost **iOSApp** module.
By convention all new KMP Apps has **composeApp** as the umbrella framework name. So lets use this instead of **shared**.